### PR TITLE
Add Serverspec and infrataster integration tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,14 +1,17 @@
 ---
 driver:
   name: vagrant
+  network:
+  - ["forwarded_port", {guest: 80, host: 8080, auto_correct: true}]
   
 provisioner:
   name: chef_solo
 
 platforms:
-  - name: ubuntu-12.04
+- name: ubuntu-12.04
 
 suites:
-  - name: default
-    run_list: recipe[roundcube::default]
-    attributes:
+- name: default
+  run_list:
+  - recipe[roundcube::default]
+  - recipe[roundcube::nginx]

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'berkshelf', '> 3.1'
 # end
 
 gem 'chef', '> 11'
+gem 'ohai', '~> 7.4' if RUBY_VERSION < '2' # Fix Ruby 1.9.3 support
 gem 'rake'
 gem 'rubocop'
 gem 'foodcritic'

--- a/Guardfile
+++ b/Guardfile
@@ -3,13 +3,13 @@
 
 guard :rubocop do
   watch(/.+\.rb$/)
-  watch(/(?:.+\/)?\.rubocop\.yml$/) { |m| File.dirname(m[0]) }
+  watch(%r{(?:.+/)?\.rubocop\.yml$}) { |m| File.dirname(m[0]) }
 end
 
 guard :foodcritic, cookbook_paths: '.', cli: ['--epic-fail', 'any'] do
-  watch(/(?:.+\/)?\attributes\.+\.rb$/)
-  watch(/(?:.+\/)?\providers\.+\.rb$/)
-  watch(/(?:.+\/)?\recipes\.+\.rb$/)
-  watch(/(?:.+\/)?\resources\.+\.rb$/)
+  watch(%r{(?:.+\/)?attributes\.+\.rb$})
+  watch(%r{(?:.+\/)?providers\.+\.rb$})
+  watch(%r{(?:.+\/)?recipes\.+\.rb$})
+  watch(%r{(?:.+\/)?resources\.+\.rb$})
   watch('metadata.rb')
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -15,7 +15,7 @@ end
 depends          'apt'
 depends          'build-essential'
 depends          'ark'
-depends          'mysql'
+depends          'mysql', '~> 5.0'
 depends          'nginx'
 depends          'openssl'
 depends          'php'

--- a/test/integration/default/serverspec/Gemfile
+++ b/test/integration/default/serverspec/Gemfile
@@ -1,0 +1,8 @@
+# encoding: UTF-8
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+source 'https://rubygems.org'
+
+gem 'serverspec', '~> 2.0'
+gem 'infrataster', '~> 0.2.6'

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -2,6 +2,35 @@
 
 require_relative 'spec_helper'
 
-describe 'default' do
-  it { skip 'write some tests' }
+describe file('/srv/roundcube') do
+  it { should be_directory }
+  it { should be_owned_by 'www-data' }
+  it { should be_grouped_into 'www-data' }
+end
+
+describe file('/srv/roundcube/index.php') do
+  it { should be_file }
+  it { should be_owned_by 'www-data' }
+  it { should be_grouped_into 'www-data' }
+  its(:content) { should match 'Roundcube Webmail IMAP Client' }
+end
+
+describe file('/srv/roundcube/config/config.inc.php') do
+  it { should be_file }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+  it { should be_readable.by_user 'www-data' }
+end
+
+describe file('/etc/roundcube') do
+  it { should be_directory }
+end
+
+describe file('/etc/roundcube/config') do
+  it { should be_symlink }
+  it { should be_linked_to '/srv/roundcube/config/config.inc.php' }
+end
+
+describe command('php -l /srv/roundcube/index.php') do
+  its(:exit_status) { should eq 0 }
 end

--- a/test/integration/default/serverspec/nginx_spec.rb
+++ b/test/integration/default/serverspec/nginx_spec.rb
@@ -1,0 +1,27 @@
+# Encoding: utf-8
+
+require_relative 'spec_helper'
+
+%w(php5-mcrypt php5-intl php5-cli php5-mysql).each do |pkg|
+  describe package(pkg) do
+    it { should be_installed }
+  end
+end
+
+describe file('/etc/nginx/sites-available/00-roundcube') do
+  it { should be_file }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+end
+
+describe server(:web) do
+  describe http('/') do
+    it 'is powered by PHP' do
+      expect(response['X-Powered-By']).to include 'PHP'
+    end
+
+    it 'responds content including "Roundcube Webmail"' do
+      expect(response.body).to include('Roundcube Webmail')
+    end
+  end
+end

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -1,10 +1,15 @@
 # Encoding: utf-8
 require 'serverspec'
+require 'infrataster/rspec'
 
 set :backend, :exec
 
 RSpec.configure do |c|
   c.before :all do
-    c.path = '/sbin:/usr/bin'
+    c.path = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
   end
+end
+
+Infrataster::Server.define(:web) do |server|
+  server.address = '127.0.0.1'
 end


### PR DESCRIPTION
Hi Chris,

First of all, thanks for all your work :smiley: I'm considering integrating this cookbook with the [`postfix-dovecot`](https://supermarket.chef.io/cookbooks/postfix-dovecot) cookbook.

This is my first PR to include some integration tests using [Serverspec](http://serverspec.org/) and [infrataster](http://infrataster.net/).

This PR also includes the following fixes:
- Depend on `mysql` cookbook version `5`: The next version does not have the `mysql::client` recipe.
- Fix some new RuboCop offenses.
