### PR TITLE
Add ChefSpec Unit Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ bundler_args: --without development integration
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1
 before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
+env:
+  - CHEF_VERSION="~> 11.0"
+  - CHEF_VERSION="~> 12.0"
+matrix:
+  exclude:
+    - rvm: 1.9.3
+      env: CHEF_VERSION="~> 12.0"
 before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ before_install:
 script:
   - bundle exec foodcritic -f any .
   - bundle exec rubocop
+  - bundle exec rspec test/unit/spec

--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,12 @@ gem 'rake'
 gem 'rubocop'
 gem 'foodcritic'
 gem 'chefspec'
-gem 'test-kitchen'
-gem 'kitchen-vagrant'
+
+group :integration do
+  gem 'test-kitchen'
+  gem 'kitchen-vagrant'
+end
+
 gem 'guard', '>= 2.6'
 gem 'guard-rubocop', '>= 1.1'
 gem 'guard-foodcritic', '>= 1.0.2'

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'berkshelf', '> 3.1'
 #   gem "vagrant-omnibus", github: "schisamo/vagrant-omnibus"
 # end
 
-gem 'chef', '> 11'
+gem 'chef', ENV.key?('CHEF_VERSION') ? ENV['CHEF_VERSION'] : '> 11'
 gem 'ohai', '~> 7.4' if RUBY_VERSION < '2' # Fix Ruby 1.9.3 support
 gem 'rake'
 gem 'rubocop'

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'ohai', '~> 7.4' if RUBY_VERSION < '2' # Fix Ruby 1.9.3 support
 gem 'rake'
 gem 'rubocop'
 gem 'foodcritic'
-gem 'chefspec'
+gem 'chefspec', '~> 4.0'
 
 group :integration do
   gem 'test-kitchen'

--- a/test/unit/spec/configure_spec.rb
+++ b/test/unit/spec/configure_spec.rb
@@ -1,0 +1,23 @@
+# Encoding: utf-8
+
+require_relative 'spec_helper'
+
+describe 'roundcube::configure' do
+  before { stub_resources }
+  let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+
+  it 'creates config.inc.php template' do
+    expect(chef_run)
+      .to create_template('/srv/roundcube/config/config.inc.php')
+      .with_source('config.inc.php.erb')
+  end
+
+  it 'creates /etc/roundcube directory' do
+    expect(chef_run).to create_directory('/etc/roundcube')
+  end
+
+  it 'creates /etc/roundcube/config symlink' do
+    expect(chef_run).to create_link('/etc/roundcube/config')
+      .with_to('/srv/roundcube/config/config.inc.php')
+  end
+end

--- a/test/unit/spec/default_spec.rb
+++ b/test/unit/spec/default_spec.rb
@@ -4,11 +4,17 @@ require_relative 'spec_helper'
 
 describe 'roundcube::default' do
   before { stub_resources }
-  describe 'ubuntu' do
-    let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
-    it 'writes some chefspec code' do
-      skip 'todo'
+  %w(
+    apt
+    php
+    mysql::client
+    roundcube::install
+    roundcube::configure
+  ).each do |recipe|
+    it "include #{recipe} recipe" do
+      expect(chef_run).to include_recipe(recipe)
     end
-  end
+  end # each recipe
 end

--- a/test/unit/spec/install_spec.rb
+++ b/test/unit/spec/install_spec.rb
@@ -1,0 +1,24 @@
+# Encoding: utf-8
+
+require_relative 'spec_helper'
+
+describe 'roundcube::install' do
+  before { stub_resources }
+  let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+  let(:version) { '1.0.2' }
+
+  it 'installs roundcube' do
+    expect(chef_run).to put_ark('roundcube')
+      .with_url(
+        'https://github.com/roundcube/roundcubemail/releases/download/'\
+        "#{version}/roundcubemail-#{version}.tar.gz"
+      )
+      .with_path('/srv')
+      .with_checksum(
+        '1c1560a7a56e6884b45c49f52961dbbb3f6bacbc7e7c755440750a1ab027171c'
+      )
+      .with_version(version)
+      .with_owner('www-data')
+      .with_group('www-data')
+  end
+end

--- a/test/unit/spec/matchers.rb
+++ b/test/unit/spec/matchers.rb
@@ -1,0 +1,10 @@
+# Encoding: utf-8
+
+# Copied from https://github.com/burtlo/ark
+# Until f6f9650 release.
+
+if defined?(ChefSpec)
+  def put_ark(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:ark, :put, resource_name)
+  end
+end

--- a/test/unit/spec/nginx_spec.rb
+++ b/test/unit/spec/nginx_spec.rb
@@ -1,0 +1,65 @@
+# Encoding: utf-8
+
+require_relative 'spec_helper'
+
+describe 'roundcube::nginx' do
+  before { stub_resources }
+  let(:chef_runner) { ChefSpec::SoloRunner.new }
+  let(:chef_run) { chef_runner.converge(described_recipe) }
+
+  it 'includes nginx recipe' do
+    expect(chef_run).to include_recipe('nginx')
+  end
+
+  it 'includes php-fpm recipe' do
+    expect(chef_run).to include_recipe('php-fpm')
+  end
+
+  %w(
+    php5-mcrypt
+    php5-intl
+    php5-cli
+    php5-mysql
+  ).each do |pkg|
+    it "installs #{pkg} package" do
+      expect(chef_run).to install_package(pkg)
+    end
+  end # each pkg
+
+  it 'includes roundcube::nginx_vhost recipe' do
+    expect(chef_run).to include_recipe('roundcube::nginx_vhost')
+  end
+
+  it 'disables default nginx site' do
+    expect(chef_run).to run_execute('nxdissite default')
+  end
+
+  it 'enables roundcube nginx site' do
+    expect(chef_run).to run_execute('nxensite 00-roundcube')
+  end
+
+  it 'enables nginx' do
+    expect(chef_run).to enable_service('nginx')
+  end
+
+  it 'starts nginx' do
+    expect(chef_run).to start_service('nginx')
+  end
+
+  context 'on Ubuntu' do
+    let(:chef_runner) do
+      ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '12.04')
+    end
+
+    %w(
+      php5-mcrypt
+      php5-intl
+      php5-cli
+      php5-mysql
+    ).each do |pkg|
+      it "installs #{pkg} package" do
+        expect(chef_run).to install_package(pkg)
+      end
+    end # each pkg
+  end # on Ubuntu
+end

--- a/test/unit/spec/nginx_vhost_spec.rb
+++ b/test/unit/spec/nginx_vhost_spec.rb
@@ -1,0 +1,27 @@
+# Encoding: utf-8
+
+require_relative 'spec_helper'
+
+describe 'roundcube::nginx_vhost' do
+  before { stub_resources }
+  let(:chef_run) do
+    # include ::nginx recipe to avoid `service[nginx] cannot be found` error
+    ChefSpec::SoloRunner.new.converge('roundcube::nginx')
+  end
+
+  it 'creates nginx roundcube site file' do
+    expect(chef_run)
+      .to create_template('/etc/nginx/sites-available/00-roundcube')
+      .with_source('nginx_vhost.erb')
+  end
+
+  context 'nginx roundcube site template' do
+    let(:resource) do
+      chef_run.template('/etc/nginx/sites-available/00-roundcube')
+    end
+
+    it 'notifies nginx restart' do
+      expect(resource).to notify('service[nginx]').to(:restart).delayed
+    end
+  end # nginx rouncube site template
+end

--- a/test/unit/spec/spec_helper.rb
+++ b/test/unit/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'rspec/expectations'
 require 'chefspec'
 require 'chefspec/berkshelf'
 require 'chef/application'
+require_relative 'matchers'
 
 ::LOG_LEVEL = :fatal
 ::UBUNTU_OPTS = {
@@ -15,6 +16,10 @@ require 'chef/application'
 }
 
 def stub_resources
+  stub_command('which nginx').and_return(true)
+  stub_command(
+    'test -d /etc/php5/fpm/pool.d || mkdir -p /etc/php5/fpm/pool.d'
+  ).and_return(true)
 end
 
 at_exit { ChefSpec::Coverage.report! }


### PR DESCRIPTION
Hello again Chris,

Here are the ChefSpec unit tests.

This PR also includes the following minor enhancements:
- Run travis-ci against Ruby `2.1`.
- Run travis-ci against Chef `11` and Chef `12`.
- Add integration group to the Gemfile to avoid installing these gems in travis-ci.
