### PR TITLE
Add CentOS and Fedora Support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,10 +8,16 @@ provisioner:
   name: chef_solo
 
 platforms:
+- name: centos-6.6
+  run_list: recipe[selinux::disabled]
 - name: debian-6.0.10
   run_list: recipe[apt]
 - name: debian-7.8
   run_list: recipe[apt]
+- name: fedora-20
+  run_list: recipe[selinux::disabled]
+- name: fedora-21
+  run_list: recipe[selinux::disabled]
 - name: ubuntu-12.04
   run_list: recipe[apt]
 - name: ubuntu-14.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,19 +11,14 @@ platforms:
 - name: centos-6.6
   run_list: recipe[selinux::disabled]
 - name: debian-6.0.10
-  run_list: recipe[apt]
 - name: debian-7.8
-  run_list: recipe[apt]
 - name: fedora-20
   run_list: recipe[selinux::disabled]
 - name: fedora-21
   run_list: recipe[selinux::disabled]
 - name: ubuntu-12.04
-  run_list: recipe[apt]
 - name: ubuntu-14.04
-  run_list: recipe[apt]
 - name: ubuntu-14.10
-  run_list: recipe[apt]
 
 suites:
 - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,10 +8,18 @@ provisioner:
   name: chef_solo
 
 platforms:
+- name: debian-6.0.10
+  run_list: recipe[apt]
+- name: debian-7.8
+  run_list: recipe[apt]
 - name: ubuntu-12.04
+  run_list: recipe[apt]
+- name: ubuntu-14.04
+  run_list: recipe[apt]
+- name: ubuntu-14.10
+  run_list: recipe[apt]
 
 suites:
 - name: default
   run_list:
-  - recipe[roundcube::default]
-  - recipe[roundcube::nginx]
+  - recipe[roundcube_test]

--- a/Berksfile
+++ b/Berksfile
@@ -2,4 +2,6 @@ source 'https://api.berkshelf.com'
 
 metadata
 
+cookbook 'selinux'
+
 cookbook 'roundcube_test', path: './test/cookbooks/roundcube_test'

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,5 @@
 source 'https://api.berkshelf.com'
 
 metadata
+
+cookbook 'roundcube_test', path: './test/cookbooks/roundcube_test'

--- a/README.md
+++ b/README.md
@@ -88,11 +88,14 @@ Installs and configures NGINX including needed dependencies and a vhost for Roun
 #### `roundcube::nginx_vhost`
 A dry recipe that provides a configuration file for an NGINX Roundcube vhost only. The NGINX service is notified to restart.
 
+#### `roundcube::php_fpm`
+A recipe that installs the PHP-FPM pool. Used by the `roundcube::nginx` recipe.
+
 Usage
 -----
 The default recipe will install and configure Roundcube intefacing GMail for both IMAP and SMTP; no web server is configured - it is recommended to also add the `roundcube::nginx` recipe to the run_list (Apache HTTPd support TODO or contrib welcome).
 
-When utilizing the nginx recipe, the `php-fpm` cookbook is used to configure PHP-FPM which by default provides a pool named 'www' with the socket residing in `/var/run/php-fpm-www.sock`.
+When utilizing the nginx recipe, the `php-fpm` cookbook is used to configure PHP-FPM and adds a pool named 'roundcube' with the socket residing in `/var/run/php-fpm-roundcube.sock`.
 
 Note: this cookbook does not configure a database server for Roundcube, this should be done independently (see prerequisites above).
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,18 @@ GRANT ALL ON *.* to roundcube@'%' IDENTIFIED BY 's3cure_as';
 Requirements
 ------------
 ### Supported Platforms
- * Debian/Ubuntu
+
+ * Debian
+ * Ubuntu
+ * CentOS
+ * Fedora
+ * RedHat
 
 Contribution for other platforms welcome (submit a pull request).
+
+### Other Requirements
+
+On RedHat based platforms, you need to disable or configure SELinux correctly to work with `mysql` and `php-fpm` cookbooks. You can use the `selinux::disabled` recipe for that.
 
 Attributes
 ----------
@@ -57,8 +66,10 @@ Attributes
  * `node['roundcube']['database']['schema']` - Name of the Roundcube database
  * `node['roundcube']['smtp']['server']` - The hostname or IP of the SMTP server for Roundcube to interface with for sending mails
  * `node['roundcube']['smtp']['port']` - The port of the SMTP server for sending mails
- * `node['roundcube']['smtp']['user']` = The SMTP username
- * `node['roundcube']['smtp']['password']` = The SMTP password
+ * `node['roundcube']['smtp']['user']` - The SMTP username
+ * `node['roundcube']['smtp']['password']` - The SMTP password
+ * `node['roundcube']['php_packages']` - The required PHP packages to install
+ * `node['roundcube']['php-fpm']['pool']` - The PHP-FPM pool name to use by Roundcube
 
 Recipes
 -------

--- a/attributes/nginx.rb
+++ b/attributes/nginx.rb
@@ -1,0 +1,2 @@
+# Disable default site
+node.default['nginx']['default_site_enabled'] = false

--- a/attributes/packages.rb
+++ b/attributes/packages.rb
@@ -1,0 +1,13 @@
+# Additional (recommended) packages
+default['roundcube']['php_packages'] =
+  case node['platform_family']
+  when 'fedora'
+    default['roundcube']['php_packages'] =
+      %w(php-mcrypt php-intl php-cli php-mysqlnd)
+  when 'rhel'
+    default['roundcube']['php_packages'] =
+      %w(php-mcrypt php-intl php-cli php-mysql)
+  else # debian
+    default['roundcube']['php_packages'] =
+      %w(php5-mcrypt php5-intl php5-cli php5-mysql)
+  end

--- a/attributes/php_fpm.rb
+++ b/attributes/php_fpm.rb
@@ -1,0 +1,2 @@
+default['php-fpm']['pools']['www']['enable'] = false
+default['roundcube']['php-fpm']['pool'] = 'roundcube'

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ description      'Installs/Configures Roundcube Webmail.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.2.0'
 
-%w(ubuntu debian).each do |os|
+%w(ubuntu debian centos fedora redhat).each do |os|
   supports os
 end
 
@@ -134,3 +134,16 @@ attribute 'roundcube/smtp/password',
           description: 'The SMTP password (default: password provided on login form).',
           default: '%p',
           recipes: ['roundcube::default', 'roundcube::configure']
+
+attribute 'roundcube/php_packages',
+          display_name: 'Roundcube PHP packages',
+          description: 'The required PHP packages to install.',
+          calculated: true,
+          recipes: ['roundcube::default', 'roundcube::install']
+
+attribute 'roundcube/php-fpm/pool',
+          display_name: 'Roundcube PHP-FPM pool',
+          description: 'The PHP-FPM pool name to use by Roundcube.',
+          default: 'roundcube',
+          recipes:
+            ['roundcube::nginx', 'roundcube::nginx_vhost', 'roundcube::php_fpm']

--- a/metadata.rb
+++ b/metadata.rb
@@ -26,6 +26,7 @@ recipe 'roundcube::install',      'Installs Roundcube only.'
 recipe 'roundcube::configure',    'Configures Roundcube.'
 recipe 'roundcube::nginx',        'Configures Roundcube on NGINX.'
 recipe 'roundcube::nginx_vhost',  'Sets up an NGINX site only.'
+recipe 'roundcube::php_fpm',      'Installs the PHP-FPM pool.'
 
 attribute 'roundcube/download_url',
           display_name: 'Roundcube Download URL',

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+node['roundcube']['php_packages'].each { |pkg| package pkg }
+
 ark 'roundcube' do
   url node['roundcube']['download_url']
   path node['roundcube']['install_dir']

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -21,15 +21,8 @@
 include_recipe 'nginx'
 include_recipe 'roundcube::php_fpm' # Required for Debian 6 and Ubuntu 10
 
-# additional (recommended) packages
-['php5-mcrypt',
- 'php5-intl',
- 'php5-cli',
- 'php5-mysql'].each { |package| package package }
-
 include_recipe 'roundcube::nginx_vhost'
 
-execute 'nxdissite default'
 execute 'nxensite 00-roundcube'
 
 service 'nginx' do

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -19,7 +19,7 @@
 #
 
 include_recipe 'nginx'
-include_recipe 'php-fpm'
+include_recipe 'roundcube::php_fpm' # Required for Debian 6 and Ubuntu 10
 
 # additional (recommended) packages
 ['php5-mcrypt',

--- a/recipes/nginx_vhost.rb
+++ b/recipes/nginx_vhost.rb
@@ -23,7 +23,9 @@ template '/etc/nginx/sites-available/00-roundcube' do
   variables(
     roundcube_dir: "#{node['roundcube']['install_dir']}/roundcube",
     listen_port: node['roundcube']['listen_port'],
-    server_name: node['roundcube']['server_name']
+    server_name: node['roundcube']['server_name'],
+    fastcgi_pass:
+      "unix:/var/run/php-fpm-#{node['roundcube']['php-fpm']['pool']}.sock"
   )
   notifies :restart, 'service[nginx]', :delayed
 end

--- a/recipes/php_fpm.rb
+++ b/recipes/php_fpm.rb
@@ -20,6 +20,16 @@
 
 include_recipe 'php-fpm'
 
+# Fix PHP session error on CentOS:
+# session_start(): open(/var/lib/php/session/..., O_RDWR) failed: No such file
+# or directory (2)
+directory '/var/lib/php/session' do
+  owner node['nginx']['user']
+  group node['nginx']['group']
+  mode '00700'
+  only_if { %w(centos).include?(node['platform']) }
+end
+
 php_fpm_pool node['roundcube']['php-fpm']['pool'] do
   user node['nginx']['user']
   group node['nginx']['group']

--- a/recipes/php_fpm.rb
+++ b/recipes/php_fpm.rb
@@ -1,9 +1,9 @@
 # Encoding: utf-8
 #
 # Cookbook Name:: roundcube
-# Recipe:: install
+# Recipe:: php_fpm
 #
-# Copyright 2014, Chris Fordham
+# Copyright 2015, Xabier de Zuazo
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,12 +18,16 @@
 # limitations under the License.
 #
 
-ark 'roundcube' do
-  url node['roundcube']['download_url']
-  path node['roundcube']['install_dir']
-  checksum node['roundcube']['download_checksum']
-  version node['roundcube']['version']
-  owner node['nginx']['user']
+include_recipe 'php-fpm'
+
+php_fpm_pool node['roundcube']['php-fpm']['pool'] do
+  user node['nginx']['user']
   group node['nginx']['group']
-  action :put
+  listen_owner node['nginx']['user']
+  listen_group node['nginx']['group']
+  listen_mode '0660'
+  # Fix php-fpm cookbook ubuntu support
+  if node['platform'] == 'ubuntu' && node['platform_version'].to_i < 12
+    process_manager 'dynamic'
+  end
 end

--- a/templates/default/nginx_vhost.erb
+++ b/templates/default/nginx_vhost.erb
@@ -1,7 +1,6 @@
 server {
        listen <%= @listen_port %>;
        server_name <%= @server_name %>;
-       disable_symlinks off;
        root <%= @roundcube_dir %>;
 
        index index.php index.html;
@@ -33,11 +32,12 @@ server {
                 log_not_found off;
        }
 
-       location ~ \.php$ {
-                try_files $uri =404;
-                include /etc/nginx/fastcgi_params;
-                fastcgi_pass unix:/var/run/php-fpm-www.sock;
-                fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+       location ~ ^(.+?\.php)(/.*)?$ {
+                try_files $1 =404;
+                include fastcgi_params;
+                fastcgi_pass <%= @fastcgi_pass %>;
+                fastcgi_param SCRIPT_FILENAME $document_root$1;
+                fastcgi_param PATH_INFO $2;
                 fastcgi_index index.php;
        }
 }

--- a/test/cookbooks/roundcube_test/README.md
+++ b/test/cookbooks/roundcube_test/README.md
@@ -1,1 +1,1 @@
-This cookbook is used with [test-kitchen](http://kitchen.ci/) to test the parent, [roundcube](https://supermarket.getchef.com/cookbooks/roundcube) cookbook.
+This cookbook is used with [test-kitchen](http://kitchen.ci/) to test the parent, [roundcube](https://supermarket.chef.io/cookbooks/roundcube) cookbook.

--- a/test/cookbooks/roundcube_test/README.md
+++ b/test/cookbooks/roundcube_test/README.md
@@ -1,0 +1,1 @@
+This cookbook is used with [test-kitchen](http://kitchen.ci/) to test the parent, [roundcube](https://supermarket.getchef.com/cookbooks/roundcube) cookbook.

--- a/test/cookbooks/roundcube_test/metadata.rb
+++ b/test/cookbooks/roundcube_test/metadata.rb
@@ -1,0 +1,13 @@
+# Encoding: utf-8
+
+name             'roundcube_test'
+maintainer       'Xabier de Zuazo'
+maintainer_email 'xabier@zuazo.org'
+license          'Apache 2.0'
+description      'This cookbook is used with test-kitchen to test the parent, '\
+                 'roundcube cookbook'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.1.0'
+
+depends 'roundcube'
+depends 'nokogiri', '~> 0.1.4'

--- a/test/cookbooks/roundcube_test/recipes/default.rb
+++ b/test/cookbooks/roundcube_test/recipes/default.rb
@@ -1,9 +1,9 @@
 # Encoding: utf-8
 #
 # Cookbook Name:: roundcube
-# Recipe:: install
+# Recipe:: default
 #
-# Copyright 2014, Chris Fordham
+# Copyright 2015, Xabier de Zuazo
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,12 +18,8 @@
 # limitations under the License.
 #
 
-ark 'roundcube' do
-  url node['roundcube']['download_url']
-  path node['roundcube']['install_dir']
-  checksum node['roundcube']['download_checksum']
-  version node['roundcube']['version']
-  owner node['nginx']['user']
-  group node['nginx']['group']
-  action :put
-end
+include_recipe 'roundcube::nginx'
+include_recipe 'roundcube::default'
+
+# Required for the integration tests
+include_recipe 'nokogiri'

--- a/test/cookbooks/roundcube_test/recipes/default.rb
+++ b/test/cookbooks/roundcube_test/recipes/default.rb
@@ -22,4 +22,5 @@ include_recipe 'roundcube::nginx'
 include_recipe 'roundcube::default'
 
 # Required for the integration tests
+package 'patch'
 include_recipe 'nokogiri'

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -2,16 +2,33 @@
 
 require_relative 'spec_helper'
 
+family = os[:family].downcase
+
+web_user, web_group =
+  if %w(debian ubuntu).include?(family)
+    %w(www-data www-data)
+  elsif %w(redhat centos fedora scientific amazon).include?(family)
+    %w(nginx nginx)
+  elsif %w(suse opensuse).include?(family)
+    %w(wwwrun www)
+  elsif %w(arch).include?(family)
+    %w(http http)
+  elsif %w(freebsd).include?(family)
+    %w(www www)
+  else
+    %w(www-data www-data)
+  end
+
 describe file('/srv/roundcube') do
   it { should be_directory }
-  it { should be_owned_by 'www-data' }
-  it { should be_grouped_into 'www-data' }
+  it { should be_owned_by web_user }
+  it { should be_grouped_into web_group }
 end
 
 describe file('/srv/roundcube/index.php') do
   it { should be_file }
-  it { should be_owned_by 'www-data' }
-  it { should be_grouped_into 'www-data' }
+  it { should be_owned_by web_user }
+  it { should be_grouped_into web_group }
   its(:content) { should match 'Roundcube Webmail IMAP Client' }
 end
 
@@ -19,7 +36,7 @@ describe file('/srv/roundcube/config/config.inc.php') do
   it { should be_file }
   it { should be_owned_by 'root' }
   it { should be_grouped_into 'root' }
-  it { should be_readable.by_user 'www-data' }
+  it { should be_readable.by_user web_user }
 end
 
 describe file('/etc/roundcube') do

--- a/test/integration/default/serverspec/nginx_spec.rb
+++ b/test/integration/default/serverspec/nginx_spec.rb
@@ -2,12 +2,6 @@
 
 require_relative 'spec_helper'
 
-%w(php5-mcrypt php5-intl php5-cli php5-mysql).each do |pkg|
-  describe package(pkg) do
-    it { should be_installed }
-  end
-end
-
 describe file('/etc/nginx/sites-available/00-roundcube') do
   it { should be_file }
   it { should be_owned_by 'root' }

--- a/test/integration/default/serverspec/packages_spec.rb
+++ b/test/integration/default/serverspec/packages_spec.rb
@@ -1,0 +1,22 @@
+# Encoding: utf-8
+
+require_relative 'spec_helper'
+
+family = os[:family].downcase
+
+packages =
+  if %w(debian ubuntu).include?(family)
+    %w(php5-mcrypt php5-intl php5-cli php5-mysql)
+  elsif %w(fedora).include?(family)
+    %w(php-mcrypt php-intl php-cli php-mysqlnd)
+  elsif %w(redhat centos scientific amazon).include?(family)
+    %w(php-mcrypt php-intl php-cli php-mysql)
+  else
+    %w(php5-mcrypt php5-intl php5-cli php5-mysql)
+  end
+
+packages.each do |pkg|
+  describe package(pkg) do
+    it { should be_installed }
+  end
+end

--- a/test/unit/spec/default_spec.rb
+++ b/test/unit/spec/default_spec.rb
@@ -13,7 +13,7 @@ describe 'roundcube::default' do
     roundcube::install
     roundcube::configure
   ).each do |recipe|
-    it "include #{recipe} recipe" do
+    it "includes #{recipe} recipe" do
       expect(chef_run).to include_recipe(recipe)
     end
   end # each recipe

--- a/test/unit/spec/install_spec.rb
+++ b/test/unit/spec/install_spec.rb
@@ -4,8 +4,71 @@ require_relative 'spec_helper'
 
 describe 'roundcube::install' do
   before { stub_resources }
-  let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+  let(:chef_runner) { ChefSpec::ServerRunner.new }
+  let(:chef_run) { chef_runner.converge(described_recipe) }
   let(:version) { '1.0.2' }
+
+  %w(
+    php5-mcrypt
+    php5-intl
+    php5-cli
+    php5-mysql
+  ).each do |pkg|
+    it "installs #{pkg} package" do
+      expect(chef_run).to install_package(pkg)
+    end
+  end # each pkg
+
+  context 'on Fedora' do
+    let(:chef_runner) do
+      ChefSpec::ServerRunner.new(platform: 'fedora', version: '20')
+    end
+
+    %w(
+      php-mcrypt
+      php-intl
+      php-cli
+      php-mysqlnd
+    ).each do |pkg|
+      it "installs #{pkg} package" do
+        expect(chef_run).to install_package(pkg)
+      end
+    end # each pkg
+  end # on Fedora
+
+  context 'on CentOS' do
+    let(:chef_runner) do
+      ChefSpec::ServerRunner.new(platform: 'centos', version: '6.6')
+    end
+
+    %w(
+      php-mcrypt
+      php-intl
+      php-cli
+      php-mysql
+    ).each do |pkg|
+      it "installs #{pkg} package" do
+        expect(chef_run).to install_package(pkg)
+      end
+    end # each pkg
+  end # on Fedora
+
+  context 'on Ubuntu' do
+    let(:chef_runner) do
+      ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '12.04')
+    end
+
+    %w(
+      php5-mcrypt
+      php5-intl
+      php5-cli
+      php5-mysql
+    ).each do |pkg|
+      it "installs #{pkg} package" do
+        expect(chef_run).to install_package(pkg)
+      end
+    end # each pkg
+  end # on Ubuntu
 
   it 'installs roundcube' do
     expect(chef_run).to put_ark('roundcube')

--- a/test/unit/spec/nginx_spec.rb
+++ b/test/unit/spec/nginx_spec.rb
@@ -11,8 +11,8 @@ describe 'roundcube::nginx' do
     expect(chef_run).to include_recipe('nginx')
   end
 
-  it 'includes php-fpm recipe' do
-    expect(chef_run).to include_recipe('php-fpm')
+  it 'includes roundcube::php_fpm recipe' do
+    expect(chef_run).to include_recipe('roundcube::php_fpm')
   end
 
   %w(

--- a/test/unit/spec/nginx_spec.rb
+++ b/test/unit/spec/nginx_spec.rb
@@ -15,23 +15,12 @@ describe 'roundcube::nginx' do
     expect(chef_run).to include_recipe('roundcube::php_fpm')
   end
 
-  %w(
-    php5-mcrypt
-    php5-intl
-    php5-cli
-    php5-mysql
-  ).each do |pkg|
-    it "installs #{pkg} package" do
-      expect(chef_run).to install_package(pkg)
-    end
-  end # each pkg
-
   it 'includes roundcube::nginx_vhost recipe' do
     expect(chef_run).to include_recipe('roundcube::nginx_vhost')
   end
 
   it 'disables default nginx site' do
-    expect(chef_run).to run_execute('nxdissite default')
+    expect(chef_run.node['nginx']['default_site_enabled']).to eq(false)
   end
 
   it 'enables roundcube nginx site' do
@@ -45,21 +34,4 @@ describe 'roundcube::nginx' do
   it 'starts nginx' do
     expect(chef_run).to start_service('nginx')
   end
-
-  context 'on Ubuntu' do
-    let(:chef_runner) do
-      ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '12.04')
-    end
-
-    %w(
-      php5-mcrypt
-      php5-intl
-      php5-cli
-      php5-mysql
-    ).each do |pkg|
-      it "installs #{pkg} package" do
-        expect(chef_run).to install_package(pkg)
-      end
-    end # each pkg
-  end # on Ubuntu
 end

--- a/test/unit/spec/php_fpm_spec.rb
+++ b/test/unit/spec/php_fpm_spec.rb
@@ -1,0 +1,20 @@
+# Encoding: utf-8
+
+require_relative 'spec_helper'
+
+describe 'roundcube::php_fpm' do
+  before { stub_resources }
+  let(:chef_runner) { ChefSpec::SoloRunner.new }
+  let(:chef_run) { chef_runner.converge(described_recipe) }
+  let(:node) { chef_runner.node }
+
+  it 'includes php-fpm recipe' do
+    expect(chef_run).to include_recipe('php-fpm')
+  end
+
+  it 'creates php FPM pool' do
+    expect(chef_run).to create_template(
+      "#{node['php-fpm']['pool_conf_dir']}/roundcube.conf"
+    )
+  end
+end

--- a/test/unit/spec/php_fpm_spec.rb
+++ b/test/unit/spec/php_fpm_spec.rb
@@ -17,4 +17,37 @@ describe 'roundcube::php_fpm' do
       "#{node['php-fpm']['pool_conf_dir']}/roundcube.conf"
     )
   end
+
+  context 'on CentOS' do
+    let(:chef_runner) do
+      ChefSpec::ServerRunner.new(platform: 'centos', version: '6.6')
+    end
+
+    it 'fixes php session directory' do
+      expect(chef_run).to create_directory('/var/lib/php/session')
+        .with_owner('nginx')
+        .with_group('nginx')
+        .with_mode('00700')
+    end
+  end # on CentOS
+
+  context 'on Fedora' do
+    let(:chef_runner) do
+      ChefSpec::ServerRunner.new(platform: 'fedora', version: '20')
+    end
+
+    it 'does not fix php session directory' do
+      expect(chef_run).to_not create_directory('/var/lib/php/session')
+    end
+  end # on Fedora
+
+  context 'on Ubuntu' do
+    let(:chef_runner) do
+      ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '12.04')
+    end
+
+    it 'does not fix php session directory' do
+      expect(chef_run).to_not create_directory('/var/lib/php/session')
+    end
+  end # on Ubuntu
 end

--- a/test/unit/spec/spec_helper.rb
+++ b/test/unit/spec/spec_helper.rb
@@ -17,9 +17,10 @@ require_relative 'matchers'
 
 def stub_resources
   stub_command('which nginx').and_return(true)
-  stub_command(
-    'test -d /etc/php5/fpm/pool.d || mkdir -p /etc/php5/fpm/pool.d'
-  ).and_return(true)
+  stub_command('test -d /etc/php5/fpm/pool.d || mkdir -p /etc/php5/fpm/pool.d')
+    .and_return(true)
+  stub_command('test -d /etc/php-fpm.d || mkdir -p /etc/php-fpm.d')
+    .and_return(true)
 end
 
 at_exit { ChefSpec::Coverage.report! }


### PR DESCRIPTION
Hi Chris,

This PR adds CentOS and Fedora support and improves Debian and Ubuntu support.

Some explanations:
- Added the `php_fpm` recipe with a new FPM pool to properly support old Debian and Ubuntu versions.
- Added the `roundcube_test` cookbook to install the integration tests dendencies.
- PHP packages installation moved from the `nginx` recipe to the `install` recipe.
- Disable nginx default site using node attributes instead of calling `nxdissite default`.
