### PR TITLE
Upgrade to Roundcube v1.1.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,6 @@ WordArray:
 
 SingleSpaceBeforeFirstArg:
   Enabled: false
+
+RegexpLiteral:
+  MaxSlashes: 0

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
-default['roundcube']['version'] = '1.0.2'
+default['roundcube']['version'] = '1.1.2'
 default['roundcube']['download_url'] = "https://github.com/roundcube/roundcubemail/releases/download/#{node['roundcube']['version']}/roundcubemail-#{node['roundcube']['version']}.tar.gz"
-default['roundcube']['download_checksum'] = '1c1560a7a56e6884b45c49f52961dbbb3f6bacbc7e7c755440750a1ab027171c'
+default['roundcube']['download_checksum'] = '70d07106468d0e82142df44bd4504183ae30487fa2d71100fb7fd58b773c0c98'
 default['roundcube']['install_dir'] = '/srv'
 default['roundcube']['default_host'] = 'ssl://imap.gmail.com:993'
 default['roundcube']['support_url'] = ''

--- a/test/unit/spec/install_spec.rb
+++ b/test/unit/spec/install_spec.rb
@@ -6,7 +6,7 @@ describe 'roundcube::install' do
   before { stub_resources }
   let(:chef_runner) { ChefSpec::ServerRunner.new }
   let(:chef_run) { chef_runner.converge(described_recipe) }
-  let(:version) { '1.0.2' }
+  let(:version) { '1.1.2' }
 
   %w(
     php5-mcrypt
@@ -78,7 +78,7 @@ describe 'roundcube::install' do
       )
       .with_path('/srv')
       .with_checksum(
-        '1c1560a7a56e6884b45c49f52961dbbb3f6bacbc7e7c755440750a1ab027171c'
+        '70d07106468d0e82142df44bd4504183ae30487fa2d71100fb7fd58b773c0c98'
       )
       .with_version(version)
       .with_owner('www-data')


### PR DESCRIPTION
The current default version `1.0.2` was released a full year ago.
- [x] unit tests pass
- [x] integration tests pass
